### PR TITLE
github actionsでCI(lint, test)を設定

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -1,0 +1,21 @@
+name: backend CI
+
+on: [push, pull_request]
+
+jobs:
+  lint_and_test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '12.x'
+      - run: | 
+          docker-compose -f ./.docker/docker-compose.yml build
+          docker-compose -f ./.docker/docker-compose.yml up -d
+          cd ./backend
+          yarn install
+          yarn lint
+          yarn test:unit
+          yarn test:integration


### PR DESCRIPTION
# どんな問題を解決するためのPRなのか？

現状CIがないのでPR作成前に実装担当者やレビュワーがテストやlintを手動実行する手間がある

特大課題は複数のPRを作成してレビューを行うことが想定されるため、上記の手間の削減のためpush時とPR作成時にlintとtestを実行するCIを作成した

動作は[こちらのPR](https://github.com/YutoKashiwagi/praha-challenge-ddd-example-app/pull/14)で確認済み

# 特に注意深く見て欲しい観点

差分にコメントで記載します
